### PR TITLE
test: Use opentofu instead of terraform in tests

### DIFF
--- a/tests/formatters-work/repo/nix4dev/flake-modules/default.nix
+++ b/tests/formatters-work/repo/nix4dev/flake-modules/default.nix
@@ -1,9 +1,21 @@
 {
-  perSystem = {
+  perSystem = { pkgs, ...}: {
     treefmt.settings.global.excludes = [
       "./expected/**"
     ];
 
     nix4dev.terraform.enable = true;
+    
+    nix4dev.overlays = [
+      (prev: self: {
+        terraform = pkgs.writeShellApplication {
+          name = "terraform";
+          runtimeInputs = [pkgs.opentofu];
+          text = ''
+            exec tofu "$@"
+          '';
+        };
+      })
+    ];    
   };
 }

--- a/tests/terraform-works/repo/nix4dev/flake-modules/default.nix
+++ b/tests/terraform-works/repo/nix4dev/flake-modules/default.nix
@@ -1,5 +1,17 @@
 {
-  perSystem = {
+  perSystem = {pkgs, ...}: {
     nix4dev.terraform.enable = true;
+
+    nix4dev.overlays = [
+      (_prev: _self: {
+        terraform = pkgs.writeShellApplication {
+          name = "terraform";
+          runtimeInputs = [pkgs.opentofu];
+          text = ''
+            exec tofu "$@"
+          '';
+        };
+      })
+    ];
   };
 }


### PR DESCRIPTION
Terraform is not in nix cache, so it must be built on every workflow run, which is slow. Opentofu is in nix cache, so it is much faster.