### PR TITLE
feat!: Rename the command used to init a repository from `setup` to `init`.

### DIFF
--- a/nix4dev-seed-modules/default.nix
+++ b/nix4dev-seed-modules/default.nix
@@ -45,7 +45,7 @@ in {
     perSystem = {system, ...}: {
       config = {
         # Setup project to use nix4dev shell.
-        packages.setup = let
+        packages.init = let
           initialSetupProjectFlake =
             nix4devFlake.inputs.flake-parts.lib.mkFlake
             {

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -15,7 +15,7 @@
     pushd "$tmp_dir"/repo
 
     # Initializing repo
-    nix run ${repoPath}#setup
+    nix run ${repoPath}#init
 
     git init .
     git add .

--- a/tests/nix4dev-seed/test.nix
+++ b/tests/nix4dev-seed/test.nix
@@ -30,7 +30,7 @@ t.makeTest (
     mkdir repo_seeded
     cd repo_seeded
 
-    nix run ../repo#setup
+    nix run ../repo#init
     mv nix4dev/flake-modules/default.nix nix4dev/flake-modules/seed.nix
     cp -r ${./repo_seeded}/* .
 


### PR DESCRIPTION
Having the command to initialize a repository and the command to (re)setup files in the repository named the same was very confusing.

BREAKING CHANGE: The name of the command used to initialize nix4dev in a repository was renamed from `setup` to `init`.