### PR TITLE
chore: Lock ./nix4dev flake

### DIFF
--- a/nix4dev/flake.lock
+++ b/nix4dev/flake.lock
@@ -73,11 +73,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1736288349,
-        "narHash": "sha256-JZFQnlS35hcC7pDkrLrFtxx3fVa+xK1ED3lB4Tu+n94=",
+        "lastModified": 1736292189,
+        "narHash": "sha256-y+tQen/7bzsZgeSktiOZni/Tqg6b/Y3jR7XFS1aizXI=",
         "owner": "jan-kouba",
         "repo": "nix4dev",
-        "rev": "dd0958673b081fc3c17f2497dfd1f00462e0111c",
+        "rev": "e03add55c25da3c9d88c0d8535177b47076cb42f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nix4dev':
    'github:jan-kouba/nix4dev/dd0958673b081fc3c17f2497dfd1f00462e0111c?narHash=sha256-JZFQnlS35hcC7pDkrLrFtxx3fVa%2BxK1ED3lB4Tu%2Bn94%3D' (2025-01-07)
  → 'github:jan-kouba/nix4dev/e03add55c25da3c9d88c0d8535177b47076cb42f?narHash=sha256-y%2BtQen/7bzsZgeSktiOZni/Tqg6b/Y3jR7XFS1aizXI%3D' (2025-01-07)