### PR TITLE
feat: Do not overwrite unchanged managed files on setup

### DIFF
--- a/flake-modules/managed-files/module.nix
+++ b/flake-modules/managed-files/module.nix
@@ -228,6 +228,7 @@
           ${pkgs.rsync}/bin/rsync \
             -r \
             --delete \
+            --checksum \
             --from0 \
             -f'.+ '<(${pkgs.jq}/bin/jq --raw-output0 "$jq_filter" "${fileListPath}") \
             -f'-! */' \


### PR DESCRIPTION
This helps various tool (nix included), because the file timestamps will not change for unchanged managed files with every call of `setup`.