### PR TITLE
feat: Do not format managed files on prepare

### DIFF
--- a/nix4dev-modules/managed-files.nix
+++ b/nix4dev-modules/managed-files.nix
@@ -1,3 +1,4 @@
+{ lib, ... }:
 {
   imports = [ ../flake-modules/managed-files/flake-module.nix ];
 
@@ -11,6 +12,11 @@
             "./nix4dev/.managed-files.list"
           ];
         };
+
+        # Disable treefmt for managed files, because they are formated on every write.
+        treefmt.settings.global.excludes = lib.attrsets.mapAttrsToList (
+          _: file: file.target
+        ) config.nix4dev.managedFiles.files;
 
         devshells.default.commands = [
           {


### PR DESCRIPTION
The managed files are formated on every write, so there is no need to format them again on every `prepare` run.