### PR TITLE
chore: Update nix4dev inputs

### DIFF
--- a/nix4dev/flake.lock
+++ b/nix4dev/flake.lock
@@ -51,11 +51,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747152390,
-        "narHash": "sha256-epuIJXQK5wJi/u+t/5rQ/6Z+xCUmMscILIaD2OHdMGE=",
+        "lastModified": 1748513719,
+        "narHash": "sha256-f0NQXh3eu37LkcURLveKvJJrztnUQdQwpOJ5mSsoK+k=",
         "owner": "jan-kouba",
         "repo": "nix4dev",
-        "rev": "3082b7696f7497d67809e4d62e338b09c78a48e2",
+        "rev": "89d98c9349dab7bc78d1fc2b3ff0a68443bff752",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746957726,
-        "narHash": "sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5+SHJkS5ID/Jo=",
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a39ed32a651fdee6842ec930761e31d1f242cb94",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "test-input-nixpkgs": {
       "locked": {
-        "lastModified": 1746957726,
-        "narHash": "sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5+SHJkS5ID/Jo=",
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a39ed32a651fdee6842ec930761e31d1f242cb94",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746989248,
-        "narHash": "sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY=",
+        "lastModified": 1748243702,
+        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "708ec80ca82e2bbafa93402ccb66a35ff87900c5",
+        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746989248,
-        "narHash": "sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY=",
+        "lastModified": 1748243702,
+        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "708ec80ca82e2bbafa93402ccb66a35ff87900c5",
+        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nix4dev':
    'github:jan-kouba/nix4dev/3082b7696f7497d67809e4d62e338b09c78a48e2?narHash=sha256-epuIJXQK5wJi/u%2Bt/5rQ/6Z%2BxCUmMscILIaD2OHdMGE%3D' (2025-05-13)
  → 'github:jan-kouba/nix4dev/89d98c9349dab7bc78d1fc2b3ff0a68443bff752?narHash=sha256-f0NQXh3eu37LkcURLveKvJJrztnUQdQwpOJ5mSsoK%2Bk%3D' (2025-05-29)
• Updated input 'nix4dev/nixpkgs':
    'github:NixOS/nixpkgs/a39ed32a651fdee6842ec930761e31d1f242cb94?narHash=sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5%2BSHJkS5ID/Jo%3D' (2025-05-11)
  → 'github:NixOS/nixpkgs/f09dede81861f3a83f7f06641ead34f02f37597f?narHash=sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk%3D' (2025-05-23)
• Updated input 'nix4dev/treefmt-nix':
    'github:numtide/treefmt-nix/708ec80ca82e2bbafa93402ccb66a35ff87900c5?narHash=sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY%3D' (2025-05-11)
  → 'github:numtide/treefmt-nix/1f3f7b784643d488ba4bf315638b2b0a4c5fb007?narHash=sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8%3D' (2025-05-26)
• Updated input 'test-input-nixpkgs':
    'github:NixOS/nixpkgs/a39ed32a651fdee6842ec930761e31d1f242cb94?narHash=sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5%2BSHJkS5ID/Jo%3D' (2025-05-11)
  → 'github:NixOS/nixpkgs/f09dede81861f3a83f7f06641ead34f02f37597f?narHash=sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk%3D' (2025-05-23)
• Updated input 'test-input-treefmt-nix':
    'github:numtide/treefmt-nix/708ec80ca82e2bbafa93402ccb66a35ff87900c5?narHash=sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY%3D' (2025-05-11)
  → 'github:numtide/treefmt-nix/1f3f7b784643d488ba4bf315638b2b0a4c5fb007?narHash=sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8%3D' (2025-05-26)