### PR TITLE
fix: Do not ignore managed files starting with ./

### DIFF
--- a/flake-modules/managed-files/flake-module.nix
+++ b/flake-modules/managed-files/flake-module.nix
@@ -95,7 +95,7 @@
           };
 
           config = {
-            target = name;
+            target = lib.path.subpath.normalise name;
             preparedSourceFile =
               if cfg.treefmt.enable then
                 nix4devLib.writeFormattedFile {
@@ -234,7 +234,7 @@
 
 
               # Update managed files
-              jq_filter='.managedFiles[] | gsub("\\*"; "\\*") | gsub("\\?"; "\\?") | gsub("\\["; "\\[") | "/" + .'
+              jq_filter='.managedFiles[] | gsub("\\*"; "\\*") | gsub("\\?"; "\\?") | gsub("\\["; "\\[") | gsub("^\\./"; "") | "/" + .'
 
               ${pkgs.rsync}/bin/rsync \
                 -r \

--- a/flake-modules/managed-files/tests/deletes-file-when-stops-being-managed/expected/.managed-files.list
+++ b/flake-modules/managed-files/tests/deletes-file-when-stops-being-managed/expected/.managed-files.list
@@ -6,6 +6,6 @@
     "This file contains list of managed files."
   ],
   "managedFiles": [
-    "second.nix"
+    "./second.nix"
   ]
 }

--- a/flake-modules/managed-files/tests/does-not-delete-files-it-should-not/expected/.managed-files.list
+++ b/flake-modules/managed-files/tests/does-not-delete-files-it-should-not/expected/.managed-files.list
@@ -6,11 +6,11 @@
     "This file contains list of managed files."
   ],
   "managedFiles": [
-    "bracket[0-9]",
-    "file",
-    "new\nline",
-    "questionmark?",
-    "star*",
-    "starstar**"
+    "./bracket[0-9]",
+    "./file",
+    "./new\nline",
+    "./questionmark?",
+    "./star*",
+    "./starstar**"
   ]
 }

--- a/flake-modules/managed-files/tests/does-not-delete-unmanaged-files/expected/.managed-files.list
+++ b/flake-modules/managed-files/tests/does-not-delete-unmanaged-files/expected/.managed-files.list
@@ -6,6 +6,6 @@
     "This file contains list of managed files."
   ],
   "managedFiles": [
-    "second.nix"
+    "./second.nix"
   ]
 }

--- a/flake-modules/managed-files/tests/write-file/default.nix
+++ b/flake-modules/managed-files/tests/write-file/default.nix
@@ -6,7 +6,7 @@
       perSystem = {
         test.enableTreefmt = false;
 
-        nix4dev.managedFiles.files."test.nix".source.text = ''
+        nix4dev.managedFiles.files."./test.nix".source.text = ''
           {
           foo = [  "barr"    ];
           }

--- a/flake-modules/managed-files/tests/write-file/expected/.managed-files.list
+++ b/flake-modules/managed-files/tests/write-file/expected/.managed-files.list
@@ -6,6 +6,6 @@
     "This file contains list of managed files."
   ],
   "managedFiles": [
-    "test.nix"
+    "./test.nix"
   ]
 }

--- a/flake-modules/managed-files/tests/write-formatted-file/expected/.managed-files.list
+++ b/flake-modules/managed-files/tests/write-formatted-file/expected/.managed-files.list
@@ -6,6 +6,6 @@
     "This file contains list of managed files."
   ],
   "managedFiles": [
-    "test.nix"
+    "./test.nix"
   ]
 }

--- a/tests/init-barebone-project/expected/nix4dev/.managed-files.list
+++ b/tests/init-barebone-project/expected/nix4dev/.managed-files.list
@@ -6,9 +6,9 @@
     "This file contains list of managed files."
   ],
   "managedFiles": [
-    ".editorconfig",
-    ".envrc",
-    ".gitignore",
-    "nix4dev/flake.nix"
+    "./.editorconfig",
+    "./.envrc",
+    "./.gitignore",
+    "./nix4dev/flake.nix"
   ]
 }


### PR DESCRIPTION
Previously, when a managed file target started with `./` the file got skipped.
To fix that, normalize all the target paths to managed files before writing them to managed files list.