### PR TITLE
feat!: Add inputs parameter to test*FlakePartsWithDir methods

### DIFF
--- a/flake-modules/managed-files/tests/default.nix
+++ b/flake-modules/managed-files/tests/default.nix
@@ -42,6 +42,7 @@
     {
       checks.managedFilesCheck = config.nix4devTestLib.testSuiteFlakePartsWithDir {
         testsDir = ./.;
+        inputs.nixpkgs = inputs.nixpkgs;
 
         extraFlakeModules = [
           self.flakeModules.managedFiles

--- a/flake-modules/test-lib/flake-module/default.nix
+++ b/flake-modules/test-lib/flake-module/default.nix
@@ -1,7 +1,6 @@
 # Library for tests.
 {
   flake-parts-lib,
-  inputs,
   lib,
   ...
 }:
@@ -43,7 +42,10 @@
           : The name of this test.
 
           `testDescription` (NullOr String)
-          : Optional description of this test
+          : Optional description of this test,
+
+          `inputs` (Any)
+          : The inputs that should be provided to the test flake.
 
           `initDir` (NullOr Path)
           : Optional directory to start this test with.
@@ -90,6 +92,7 @@
           {
             testName,
             testDescription ? null,
+            inputs,
             initDir,
             steps,
             expectedDir,
@@ -222,6 +225,9 @@
               This will be merged with the excludeFiles passed as the parameter to the `testSuiteFlakePartsWithDir` function.
               Defaults to `[]`.
 
+          `inputs` (Any)
+          : The inputs that should be provided to the test flakes.
+
           `extraFlakeModules` (ListOf FlakePartsModule)
           : The extra flake modules to import in every step of every test when constructing the flake.
             It can be used to do some common setup (e.g. of the commands to run in every step).
@@ -253,6 +259,7 @@
         testSuiteFlakePartsWithDir =
           {
             testsDir,
+            inputs,
             extraFlakeModules ? [ ],
             excludeFiles ? [ ],
           }:
@@ -284,6 +291,7 @@
                   expectedDir
                   testName
                   testDescription
+                  inputs
                   ;
                 inherit (finalTestExpr) steps;
                 excludeFiles = finalExcludeFiles;

--- a/flake-modules/test-lib/tests/default.nix
+++ b/flake-modules/test-lib/tests/default.nix
@@ -3,6 +3,7 @@
     { config, ... }:
     {
       checks.testLibChecks = config.nix4devTestLib.testSuiteFlakePartsWithDir {
+        inputs = { };
         testsDir = ./.;
 
         excludeFiles = [ "./global-exclude-file" ];


### PR DESCRIPTION
Previously, the inputs of the flake using the test module were always used.
This is very rigid and sometimes can block implementation of a test. So now, the inputs that are passed to the constructed flake must be always explicitly specified.