### PR TITLE
feat: Import the nix4dev flake module when generating template

### DIFF
--- a/flake-modules/nix4dev-templates/tests/template-works/expected/nix4dev/templates/test/nix4dev/flake-modules/default.nix
+++ b/flake-modules/nix4dev-templates/tests/template-works/expected/nix4dev/templates/test/nix4dev/flake-modules/default.nix
@@ -1,3 +1,8 @@
 {
+  perSystem.nix4dev.flake = {
+    extraInputs.dummy-flake.url = "github:jan-kouba/dummy-repo";
+    extraFlakeModules = [ "inputs.dummy-flake.flakeModules.default" ];
+  };
+
   # Add your config here
 }

--- a/flake-modules/nix4dev-templates/tests/template-works/expected/nix4dev/templates/test/nix4dev/flake.nix
+++ b/flake-modules/nix4dev-templates/tests/template-works/expected/nix4dev/templates/test/nix4dev/flake.nix
@@ -3,6 +3,9 @@
 
   # To change flake inputs, use the `nix4dev.flake.extraInputs` option.
   inputs = {
+    "dummy-flake" = {
+      "url" = "github:jan-kouba/dummy-repo";
+    };
     "nix4dev" = {
       "url" = "github:jan-kouba/nix4dev";
     };
@@ -21,6 +24,7 @@
         in
         [
           inputs.nix4dev.flakeModules.default
+          inputs.dummy-flake.flakeModules.default
           (assertFileExists ./flake-modules/default.nix ''
             Default flake module not found. To create an empty default module execute:
 

--- a/flake-modules/nix4dev-templates/tests/template-works/template-default.nix
+++ b/flake-modules/nix4dev-templates/tests/template-works/template-default.nix
@@ -1,3 +1,8 @@
 {
+  perSystem.nix4dev.flake = {
+    extraInputs.dummy-flake.url = "github:jan-kouba/dummy-repo";
+    extraFlakeModules = [ "inputs.dummy-flake.flakeModules.default" ];
+  };
+
   # Add your config here
 }


### PR DESCRIPTION
Every template must configure the ./nix4dev/flake-modules/default.nix file using the extraFiles option. The file is then imported as flake module into the devshell used to generate template files.