### PR TITLE
chore: Remove terraform overrides by opentofu in tests of formatters

### DIFF
--- a/tests/formatters-work/repo/nix4dev/flake-modules/default.nix
+++ b/tests/formatters-work/repo/nix4dev/flake-modules/default.nix
@@ -1,21 +1,9 @@
 {
-  perSystem = { pkgs, ...}: {
+  perSystem = {
     treefmt.settings.global.excludes = [
       "expected/**"
     ];
 
     nix4dev.terraform.enable = true;
-
-    nix4dev.overlays = [
-      (prev: self: {
-        terraform = pkgs.writeShellApplication {
-          name = "terraform";
-          runtimeInputs = [pkgs.opentofu];
-          text = ''
-            exec tofu "$@"
-          '';
-        };
-      })
-    ];
   };
 }


### PR DESCRIPTION
It is not needed anymore because the treefmt uses opentofu anyway