### PR TITLE
test: Don't use terraform in tests

### DIFF
--- a/flake-modules/nix4dev/tests/prepare-formats-files/default.nix
+++ b/flake-modules/nix4dev/tests/prepare-formats-files/default.nix
@@ -4,7 +4,7 @@
       perSystem =
         { config, ... }:
         {
-          nix4dev.terraform.enable = true;
+          nix4dev.opentofu.enable = true;
 
           test.commandsToExecute = [
             ''


### PR DESCRIPTION
It slows down CI, because the terraform package needs to be compiled from sources.