### PR TITLE
feat: Fix and improve the managed flake.nix files

### DIFF
--- a/flake-modules/nix4dev/flake-module/lib/flake-nix-options.nix
+++ b/flake-modules/nix4dev/flake-module/lib/flake-nix-options.nix
@@ -15,13 +15,15 @@
               "set" = ''
                 {
                   ${l.strings.concatStrings (
-                    l.attrsets.mapAttrsToList (name: value: ''"${name}" = ${printFlakeInputs value};'') x
+                    l.attrsets.mapAttrsToList (
+                      name: value: ''${lib.strings.escapeNixIdentifier name} = ${printFlakeInputs value};''
+                    ) x
                   )}
                 }
               '';
               "int" = l.toString x;
               "bool" = if x then "true" else "false";
-              "string" = ''"${x}"'';
+              "string" = lib.strings.escapeNixString x;
               "list" = "[ ${l.concatStringsSep " " (printFlakeInputs x)} ]";
               "float" = l.toString x;
             }

--- a/flake-modules/nix4dev/templates/tests/template-works/expected/flake.nix
+++ b/flake-modules/nix4dev/templates/tests/template-works/expected/flake.nix
@@ -3,16 +3,16 @@
 
   # To change flake inputs, use the `nix4dev.projectFlake.inputs` option.
   inputs = {
-    "flake-parts" = {
-      "inputs" = {
-        "nixpkgs-lib" = {
-          "follows" = "nixpkgs";
+    flake-parts = {
+      inputs = {
+        nixpkgs-lib = {
+          follows = "nixpkgs";
         };
       };
-      "url" = "github:hercules-ci/flake-parts";
+      url = "github:hercules-ci/flake-parts";
     };
-    "nixpkgs" = {
-      "url" = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixos-25.05";
     };
   };
 

--- a/flake-modules/nix4dev/templates/tests/template-works/expected/nix4dev/templates/test/nix4dev/flake.nix
+++ b/flake-modules/nix4dev/templates/tests/template-works/expected/nix4dev/templates/test/nix4dev/flake.nix
@@ -3,14 +3,14 @@
 
   # To change flake inputs, use the `nix4dev.flake.inputs` option.
   inputs = {
-    "dummy-flake" = {
-      "url" = "github:jan-kouba/dummy-repo";
+    dummy-flake = {
+      url = "github:jan-kouba/dummy-repo";
     };
-    "flake-parts" = {
-      "follows" = "nix4dev/flake-parts";
+    flake-parts = {
+      follows = "nix4dev/flake-parts";
     };
-    "nix4dev" = {
-      "url" = "github:jan-kouba/nix4dev";
+    nix4dev = {
+      url = "github:jan-kouba/nix4dev";
     };
   };
 

--- a/nix4dev/templates/default/nix4dev/flake.nix
+++ b/nix4dev/templates/default/nix4dev/flake.nix
@@ -3,8 +3,8 @@
 
   # To change flake inputs, use the `nix4dev.flake.extraInputs` option.
   inputs = {
-    "nix4dev" = {
-      "url" = "github:jan-kouba/nix4dev";
+    nix4dev = {
+      url = "github:jan-kouba/nix4dev";
     };
   };
 

--- a/tests/init-barebone-project/expected/nix4dev/flake.nix
+++ b/tests/init-barebone-project/expected/nix4dev/flake.nix
@@ -3,8 +3,8 @@
 
   # To change flake inputs, use the `nix4dev.flake.extraInputs` option.
   inputs = {
-    "nix4dev" = {
-      "url" = "github:jan-kouba/nix4dev";
+    nix4dev = {
+      url = "github:jan-kouba/nix4dev";
     };
   };
 


### PR DESCRIPTION
Do not wrap all nix identifiers into double quotes and properly escape the identifiers and nix strings.