### PR TITLE
feat: Do not eagerly build contents of all managed files when entering devshell

### DIFF
--- a/flake-modules/nix4dev/flake-module/managed-files.nix
+++ b/flake-modules/nix4dev/flake-module/managed-files.nix
@@ -3,7 +3,15 @@
   imports = [ ../../managed-files/flake-module.nix ];
 
   perSystem =
-    { config, ... }:
+    { config, pkgs, ... }:
+    let
+      lazyWriteManagedFiles = pkgs.writeScriptBin "lazy-write-managed-files" ''
+        ${pkgs.nix}/bin/nix run \
+          --extra-experimental-features nix-command \
+          --extra-experimental-features flakes \
+          "$PRJ_ROOT"/nix4dev#eager-write-managed-files
+      '';
+    in
     {
       config = {
         nix4dev.managedFiles = {
@@ -22,12 +30,16 @@
           {
             name = "write-managed-files";
             help = "(Over)writes managed files.";
-            package = config.nix4dev.managedFiles.writeFiles;
+            package = lazyWriteManagedFiles;
             category = "setup sub-commands";
           }
         ];
 
-        nix4dev.setupCommands = [ "${config.nix4dev.managedFiles.writeFiles}/bin/write-managed-files" ];
+        nix4dev.setupCommands = [ "${lazyWriteManagedFiles}/bin/lazy-write-managed-files" ];
+
+        packages = {
+          eager-write-managed-files = config.nix4dev.managedFiles.writeFiles;
+        };
       };
     };
 }

--- a/flake-modules/nix4dev/templates/tests/template-works/default.nix
+++ b/flake-modules/nix4dev/templates/tests/template-works/default.nix
@@ -28,9 +28,7 @@ in
         perSystem =
           { config, ... }:
           {
-            test.commandsToExecute = [
-              ''PRJ_ROOT="$out" ${config.packages.setup}/bin/setup''
-            ];
+            test.commandsToExecute = [ ''${config.nix4dev.managedFiles.updateFiles} "$out"'' ];
           };
       }
     ];

--- a/flake-modules/nix4dev/tests/default.nix
+++ b/flake-modules/nix4dev/tests/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ./opentofu-works
     ./prepare-formats-files
+    ./devshell-does-not-depend-on-managed-files-contents
     ./terraform-works
     ./write-managed-formatted-file
   ];

--- a/flake-modules/nix4dev/tests/devshell-does-not-depend-on-managed-files-contents/default.nix
+++ b/flake-modules/nix4dev/tests/devshell-does-not-depend-on-managed-files-contents/default.nix
@@ -1,0 +1,27 @@
+{
+  # Test that the devshell (and the setup command) does not depend
+  # on the derivations that build the contents of the files.
+  perSystem.config.nix4dev.flakePartsTests.suites."nix4dev".tests."devshell-does-not-depend-on-managed-files-contents" =
+    {
+      expected = null;
+
+      steps = [
+        ({
+          perSystem =
+            { config, ... }:
+            {
+              nix4dev.managedFiles.files = {
+                "test.txt".source.file =
+                  assert false;
+                  "ignore";
+              };
+
+              test.commandsToExecute = [
+                "${config.devShells.default}/entrypoint true"
+
+              ];
+            };
+        })
+      ];
+    };
+}


### PR DESCRIPTION
Previously, when entering devshell, the contents of the managed files were built, becuase the setup script (transitively) calls something like `rsync -r ${src} ${target}`, where `src` is some derivation. This was quite anoying, when the `src` depeded on e.g. project source files, e.g. because we generate documentation / readme from sources using the managedFiles.

Now the setup script calls `nix run ./nix4dev#eager-write-managed-files` which is the actual script that contains all the rsync calls with paths to the contents of managed files.